### PR TITLE
Added support for bulk join and leave

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
  <groupId>com.corundumstudio.socketio</groupId>
  <artifactId>netty-socketio</artifactId>
- <version>1.7.18</version>
+ <version>1.7.19-SNAPSHOT</version>
  <packaging>bundle</packaging>
  <name>NettySocketIO</name>
  <description>Socket.IO server implemented on Java</description>
@@ -14,7 +14,7 @@
     <url>scm:git:git@github.com:mrniko/netty-socketio.git</url>
     <connection>scm:git:git@github.com:mrniko/netty-socketio.git</connection>
     <developerConnection>scm:git:git@github.com:mrniko/netty-socketio.git</developerConnection>
-   <tag>netty-socketio-1.7.18</tag>
+   <tag>netty-socketio-1.7.19-SNAPSHOT</tag>
   </scm>
 
  <licenses>

--- a/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
+++ b/src/main/java/com/corundumstudio/socketio/SocketIOClient.java
@@ -15,12 +15,12 @@
  */
 package com.corundumstudio.socketio;
 
+import com.corundumstudio.socketio.protocol.Packet;
+import com.corundumstudio.socketio.store.Store;
+
 import java.net.SocketAddress;
 import java.util.Set;
 import java.util.UUID;
-
-import com.corundumstudio.socketio.protocol.Packet;
-import com.corundumstudio.socketio.store.Store;
 
 
 /**
@@ -95,12 +95,26 @@ public interface SocketIOClient extends ClientOperations, Store {
      */
     void joinRoom(String room);
 
+  /**
+   * Join client to rooms
+   *
+   * @param rooms - names of rooms
+   */
+  void joinRooms(Set<String> rooms);
+
     /**
-     * Join client to room
+     * Leave client from room
      *
      * @param room - name of room
      */
     void leaveRoom(String room);
+
+  /**
+   * Leave client from rooms
+   *
+   * @param rooms - names of rooms
+   */
+  void leaveRooms(Set<String> rooms);
 
     /**
      * Get all rooms a client is joined in.

--- a/src/main/java/com/corundumstudio/socketio/store/pubsub/BulkJoinLeaveMessage.java
+++ b/src/main/java/com/corundumstudio/socketio/store/pubsub/BulkJoinLeaveMessage.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2012-2019 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.corundumstudio.socketio.store.pubsub;
+
+import java.util.Set;
+import java.util.UUID;
+
+public class BulkJoinLeaveMessage extends PubSubMessage {
+
+    private static final long serialVersionUID = -944515928988033174L;
+
+    private UUID sessionId;
+    private String namespace;
+    private Set<String> rooms;
+
+    public BulkJoinLeaveMessage() {
+    }
+
+    public BulkJoinLeaveMessage(UUID id, Set<String> rooms, String namespace) {
+        super();
+        this.sessionId = id;
+        this.rooms = rooms;
+        this.namespace = namespace;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public UUID getSessionId() {
+        return sessionId;
+    }
+
+    public Set<String> getRooms() {
+        return rooms;
+    }
+
+}

--- a/src/main/java/com/corundumstudio/socketio/store/pubsub/PubSubType.java
+++ b/src/main/java/com/corundumstudio/socketio/store/pubsub/PubSubType.java
@@ -17,7 +17,7 @@ package com.corundumstudio.socketio.store.pubsub;
 
 public enum PubSubType {
 
-    CONNECT, DISCONNECT, JOIN, LEAVE, DISPATCH;
+    CONNECT, DISCONNECT, JOIN, BULK_JOIN, LEAVE, BULK_LEAVE, DISPATCH;
 
     @Override
     public String toString() {

--- a/src/main/java/com/corundumstudio/socketio/transport/NamespaceClient.java
+++ b/src/main/java/com/corundumstudio/socketio/transport/NamespaceClient.java
@@ -17,12 +17,10 @@ package com.corundumstudio.socketio.transport;
 
 import java.net.SocketAddress;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.corundumstudio.socketio.AckCallback;
 import com.corundumstudio.socketio.HandshakeData;
@@ -32,6 +30,8 @@ import com.corundumstudio.socketio.handler.ClientHead;
 import com.corundumstudio.socketio.namespace.Namespace;
 import com.corundumstudio.socketio.protocol.Packet;
 import com.corundumstudio.socketio.protocol.PacketType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NamespaceClient implements SocketIOClient {
 
@@ -173,8 +173,18 @@ public class NamespaceClient implements SocketIOClient {
     }
 
     @Override
+    public void joinRooms(Set<String> rooms) {
+        namespace.joinRooms(rooms, getSessionId());
+    }
+
+    @Override
     public void leaveRoom(String room) {
         namespace.leaveRoom(room, getSessionId());
+    }
+
+    @Override
+    public void leaveRooms(Set<String> rooms) {
+        namespace.leaveRooms(rooms, getSessionId());
     }
 
     @Override


### PR DESCRIPTION
We have a large number of rooms a socket client can subscribe to, and when a client connects to our server, we pull all the rooms they were previously subscribed to from our backend and issue a join request for all the rooms, this also ends up issuing a publish on pubsub (redis in our case) for JOIN / LEAVE events This is causing high CPU spikes

Added a bulk JOIN / LEAVE API to allow the above use case to be handled in a more efficient manner for us. This will allow client to join a large number of rooms at the same time without causing a lot of resource strain